### PR TITLE
Implement MAML-based adaptive filter

### DIFF
--- a/dataloader/generate_data.py
+++ b/dataloader/generate_data.py
@@ -79,3 +79,41 @@ def generate_anc_training_data(path_dir: str,
         Fx_data[:, jj] = np.concatenate([x1, x2], axis=0)
 
     return Fx_data, Di_data
+
+
+def generate_task_batch(length: int,
+                        num_refs: int,
+                        with_secondary: bool = False,
+                        num_errs: int = 1,
+                        sec_len: int = 128):
+    """Generate a random ANC task for quick experiments.
+
+    This utility is primarily for algorithm validation when no
+    measured path data are provided. It synthesizes random reference
+    and disturbance signals. When ``with_secondary`` is True, a random
+    secondary path matrix is also returned.
+
+    Args:
+        length (int): Number of time-domain samples.
+        num_refs (int): Number of reference channels.
+        with_secondary (bool): Whether to generate a secondary path.
+        num_errs (int): Number of error microphones.
+        sec_len (int): Length of the secondary path impulse response.
+
+    Returns:
+        If ``with_secondary`` is True:
+            Tuple[np.ndarray, np.ndarray, np.ndarray]
+            → (Ref, E, sec_path)
+        Else:
+            Tuple[np.ndarray, np.ndarray]
+            → (Ref, Di)
+    """
+
+    Ref = np.random.randn(length, num_refs)
+    Di = np.random.randn(length, num_errs)
+
+    if with_secondary:
+        sec_path = np.random.randn(sec_len, num_refs * num_errs)
+        return Ref, Di, sec_path
+
+    return Ref, Di

--- a/models/maml_filter.py
+++ b/models/maml_filter.py
@@ -1,56 +1,56 @@
-# 🔶 封装 MAML 更新逻辑（内循环）
+"""MAML-style initialization for multi-reference ANC."""
+
 import numpy as np
 
+from .control_filter import ControlFilter
+
+
 class MAMLFilter(ControlFilter):
-    """
-    MAML-based filter initialization for ANC with multi-channel references.
-    """
-    def maml_initial(self, Fx, Di, mu, lamda, epslon):
-        """
-        Perform MAML-style initialization update.
+    """Meta-learning based control filter for ANC."""
+
+    def adapt(self, Fx, Di, mu, lamda, epsilon):
+        """Perform one MAML initialization update.
 
         Args:
-            Fx (np.ndarray): [Len_N × num_refs], time-domain reference signal.
-            Di (np.ndarray): [Len_N × 1], desired signal (interference).
-            mu (float): step size.
+            Fx (np.ndarray): [Len_N × num_refs] time-domain reference signal.
+            Di (np.ndarray): [Len_N × 1] desired signal (disturbance).
+            mu (float): step size for the inner update.
             lamda (float): forgetting factor.
-            epslon (float): scaling factor for meta-gradient.
+            epsilon (float): scaling factor for the meta-gradient.
 
         Returns:
-            float: Initial error (for tracking purposes).
+            float: Residual error after the fast adaptation step.
         """
+
         Len_N, num_refs = Fx.shape
 
-        # Flip time axis for both inputs (reverse time)
+        # Reverse time axis for references and disturbance
         Fx_flip = np.flipud(Fx)
         Di_flip = np.flipud(Di)
 
-        # Concatenate reversed references into column vector
-        Fx_concat = Fx_flip.flatten(order='F').reshape(-1, 1)
+        # Stack reversed references into a single column vector
+        Fx_concat = Fx_flip.flatten(order="F").reshape(-1, 1)
 
-        # 1-step error and fast update
+        # One-step fast adaptation
         e1 = Di_flip[0] - self.apply(Fx_concat)
-        Wo = self.Phi + mu * e1 * Fx_concat  # fast-updated weights
+        Wo = self.Phi + mu * e1 * Fx_concat
 
-        # Gradient accumulation
+        # Accumulate meta-gradient
         Grad = np.zeros_like(self.Phi)
         for jj in range(Len_N):
             Fd_stack = []
             for ch in range(num_refs):
-                Fd_j = np.concatenate([
-                    Fx_flip[jj:, ch],
-                    np.zeros(jj)
-                ])
+                Fd_j = np.concatenate((Fx_flip[jj:, ch], np.zeros(jj)))
                 Fd_stack.append(Fd_j)
             Fd_stack = np.concatenate(Fd_stack).reshape(-1, 1)
 
             e_j = Di_flip[jj] - float(np.dot(Wo.T, Fd_stack))
-            Grad += epslon * (mu / Len_N) * e_j * Fd_stack * (lamda ** jj)
+            Grad += epsilon * (mu / Len_N) * e_j * Fd_stack * (lamda ** jj)
 
             if jj == 0:
-                Er = e_j  # record first error
+                Er = e_j
 
-        # Meta-update
+        # Meta update of initialization weights
         self.Phi += Grad
 
         return float(Er)


### PR DESCRIPTION
## Summary
- implement MAML-based adaptive filter with meta-gradient update and import base filter
- add synthetic task generator for quick experiments

## Testing
- `python -m py_compile models/maml_filter.py dataloader/generate_data.py`
- unable to run runtime test because `numpy` is missing and installation failed (`ModuleNotFoundError: No module named 'numpy'`)


------
https://chatgpt.com/codex/tasks/task_e_6893005bd644832284b61c3da1c3e6ec