### PR TITLE
Add unit tests for data generation, MAML filter and FxLMS

### DIFF
--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -1,0 +1,47 @@
+import numpy as np
+import scipy.io as sio
+
+from dataloader.generate_data import generate_anc_training_data, generate_task_batch
+
+
+def test_generate_anc_training_data_shapes_values(tmp_path):
+    np.random.seed(0)
+    path_dir = tmp_path / 'paths'
+    path_dir.mkdir()
+    # Create two simple primary path files
+    G = np.zeros((10, 4))
+    G[:, 0] = np.array([1, 0.5, 0, 0, 0, 0, 0, 0, 0, 0])
+    G[:, 2] = np.array([0.3, 0.2, 0, 0, 0, 0, 0, 0, 0, 0])
+    for i in range(2):
+        sio.savemat(path_dir / f'G_{i}.mat', {'G_matrix': G})
+
+    # Secondary path file
+    sec_path = np.array([[1.0], [0.5], [0.2]])
+    sio.savemat(tmp_path / 'sec.mat', {'S': sec_path})
+
+    Fx, Di = generate_anc_training_data(
+        str(path_dir),
+        ['G_0.mat', 'G_1.mat'],
+        str(tmp_path / 'sec.mat'),
+        N_epcho=2,
+        Len_N=8,
+        fs=16000,
+    )
+
+    assert Fx.shape == (8, 2)
+    assert Di.shape == (8, 2)
+    assert np.isfinite(Fx).all() and np.isfinite(Di).all()
+    assert not np.allclose(Fx, 0) and not np.allclose(Di, 0)
+
+
+def test_generate_task_batch_shapes_values():
+    np.random.seed(1)
+    Ref, Di = generate_task_batch(length=10, num_refs=2, num_errs=3)
+    assert Ref.shape == (10, 2)
+    assert Di.shape == (10, 3)
+    assert np.isfinite(Ref).all() and np.isfinite(Di).all()
+    Ref2, Di2, sec = generate_task_batch(length=10, num_refs=2, num_errs=3, with_secondary=True, sec_len=4)
+    assert Ref2.shape == (10, 2)
+    assert Di2.shape == (10, 3)
+    assert sec.shape == (4, 2 * 3)
+    assert np.isfinite(sec).all()

--- a/tests/test_fxlms.py
+++ b/tests/test_fxlms.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from algorithms.fxlms import multi_ref_multi_chan_fxlms
+
+
+def test_multi_ref_multi_chan_fxlms_converges():
+    np.random.seed(0)
+    length = 200
+    Ref = np.random.randn(length, 1)
+    E = -Ref.copy()
+    sec_path = np.array([[1.0]])
+    W, e = multi_ref_multi_chan_fxlms(Ref, E, filter_len=1, sec_path=sec_path, stepsize=0.5)
+    assert W.shape == (1, 1)
+    assert e.shape == (length, 1)
+    assert np.mean(np.abs(e[-50:])) < 0.1

--- a/tests/test_maml_filter.py
+++ b/tests/test_maml_filter.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from models.maml_filter import MAMLFilter
+
+
+def test_maml_initial_gradient_and_error():
+    Fx = np.array([[1.0], [2.0]])
+    Di = np.array([[0.5], [-1.5]])
+    filt = MAMLFilter(filter_len=2, num_refs=1)
+    mu, lamda, eps = 0.1, 0.9, 0.5
+    err = filt.maml_initial(Fx, Di, mu, lamda, eps)
+
+    # Expected calculations
+    f1, f2 = 1.0, 2.0
+    d1, d2 = 0.5, -1.5
+    e1 = d2
+    Wo = mu * e1 * np.array([[f2], [f1]])
+    e_j0 = d2 - float(np.dot(Wo.T, np.array([[f2], [f1]])))
+    e_j1 = d1 - float(np.dot(Wo.T, np.array([[f1], [0.0]])))
+    grad = (
+        eps * (mu / 2) * e_j0 * np.array([[f2], [f1]]) +
+        eps * (mu / 2) * lamda * e_j1 * np.array([[f1], [0.0]])
+    )
+    expected_Phi = grad
+    expected_err = e_j0
+
+    assert np.allclose(filt.Phi, expected_Phi)
+    assert np.isclose(err, expected_err)


### PR DESCRIPTION
## Summary
- add shape/value tests for `generate_anc_training_data` and `generate_task_batch`
- validate gradient update and error output in `MAMLFilter.maml_initial`
- ensure `multi_ref_multi_chan_fxlms` converges on synthetic data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68937cd3fd908322861474de2b1f71e7